### PR TITLE
Update code for hmatrix-0.18

### DIFF
--- a/Numeric/Minimization/QuadProgPP.hs
+++ b/Numeric/Minimization/QuadProgPP.hs
@@ -17,7 +17,6 @@ import Foreign.Marshal.Alloc
 import Foreign.Ptr
 import Foreign.Storable
 import Numeric.LinearAlgebra.Data
-import Numeric.LinearAlgebra.Devel
 import System.IO.Unsafe (unsafePerformIO)
 import Prelude
 
@@ -91,9 +90,11 @@ solveQuadProg (g, g0) (split -> (ce, ce0)) (split -> (ci, ci0))
                             (fromIntegral nVar)
                         in return $ Right (solutionVec, best)
     where
-        mat' (Just m) f = appMatrixLen f m
+        mat' (Just m) f = VS.unsafeWith (flatten m) $ \ptr ->
+            f (fromIntegral $ rows m) (fromIntegral $ cols m) ptr
         mat' Nothing f = f 0 0 nullPtr
-        vec' (Just v) f = appVectorLen f v
+        vec' (Just v) f = VS.unsafeWith v $ \ptr ->
+            f (fromIntegral $ VS.length v) ptr
         vec' Nothing f = f 0 nullPtr
 
 split :: Maybe (a, b) -> (Maybe a, Maybe b)

--- a/hmatrix-quadprogpp.cabal
+++ b/hmatrix-quadprogpp.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                hmatrix-quadprogpp
-version:             0.3.0.0
+version:             0.3.0.1
 synopsis:            Bindings to the QuadProg++ quadratic programming library
 description:
   Bindings to QuadProg++, a C++ library for quadratic programming.

--- a/hmatrix-quadprogpp.cabal
+++ b/hmatrix-quadprogpp.cabal
@@ -25,5 +25,5 @@ library
   c-sources: c++/binding.cxx
   exposed-modules:     Numeric.Minimization.QuadProgPP
   -- other-modules:       
-  build-depends:       base >= 4.5 && < 4.9, vector >= 0.9, hmatrix >= 0.16
+  build-depends:       base >= 4.5 && < 5.1, vector >= 0.9, hmatrix >= 0.16
   extra-libraries:  QuadProgpp, stdc++


### PR DESCRIPTION
The `appVectorLen` and `appMatrixLen` functions are no longer available.