### PR TITLE
Update for the latest version of QuadProg++

### DIFF
--- a/c++/binding.cxx
+++ b/c++/binding.cxx
@@ -2,6 +2,14 @@
 # include <exception>
 # include <string.h>
 
+/* These namespaces may or may not be defined, depending on the version of
+ * QuadProg++. Here we make sure the are all defined, so that we can be `using`
+ * them later.
+ */
+
+namespace QuadProgPP{}
+namespace quadprogpp{}
+
 extern "C" double hs_solve_quadprog(
   int n_vars, int n_ce, int n_ci,
   const double *G_,
@@ -13,7 +21,11 @@ extern "C" double hs_solve_quadprog(
   double *x_,
   const char **p_errorstr) try
 {
+  /* Depending on the version, the names may be in the global namespace, the
+   * QuadProgPP namespace or the quadprogpp namespace.
+   */
   using namespace QuadProgPP;
+  using namespace quadprogpp;
   Matrix<double> G(G_, n_vars, n_vars);
   Vector<double> g0(g0_, n_vars);
   Matrix<double> CE(CE_, n_vars, n_ce);

--- a/c++/binding.cxx
+++ b/c++/binding.cxx
@@ -1,4 +1,4 @@
-# include <QuadProg++.hh>
+# include <QuadProg++/QuadProg++.hh>
 # include <exception>
 # include <string.h>
 

--- a/hmatrix-quadprogpp.cabal
+++ b/hmatrix-quadprogpp.cabal
@@ -6,7 +6,7 @@ version:             0.3.0.1
 synopsis:            Bindings to the QuadProg++ quadratic programming library
 description:
   Bindings to QuadProg++, a C++ library for quadratic programming.
-  <http://sourceforge.net/projects/quadprog/>
+  <https://github.com/liuq/QuadProgpp>
 license:             BSD3
 license-file:        LICENSE
 author:              Alex Lang, Takano Akio

--- a/hmatrix-quadprogpp.cabal
+++ b/hmatrix-quadprogpp.cabal
@@ -26,4 +26,4 @@ library
   exposed-modules:     Numeric.Minimization.QuadProgPP
   -- other-modules:       
   build-depends:       base >= 4.5 && < 5.1, vector >= 0.9, hmatrix >= 0.16
-  extra-libraries:  QuadProgpp, stdc++
+  extra-libraries:  quadprog, stdc++

--- a/hmatrix-quadprogpp.cabal
+++ b/hmatrix-quadprogpp.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                hmatrix-quadprogpp
-version:             0.3.0.1
+version:             0.4.0.0
 synopsis:            Bindings to the QuadProg++ quadratic programming library
 description:
   Bindings to QuadProg++, a C++ library for quadratic programming.


### PR DESCRIPTION
Now QuadProg++ is hosted on Github, with changes to some names.